### PR TITLE
Add website and repository to appinfo/info.xml

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -16,7 +16,9 @@
     <category>monitoring</category>
     <category>security</category>
     <category>tools</category>
+    <website>https://github.com/undo-ransomware/ransomware_detection</website>
     <bugs>https://github.com/undo-ransomware/ransomware_detection/issues</bugs>
+    <repository>https://github.com/undo-ransomware/ransomware_detection.git</repository>
     <screenshot>https://github.com/undo-ransomware/ransomware_detection/raw/master/screenshots/monitoring-0.3.0.png</screenshot>
     <screenshot>https://github.com/undo-ransomware/ransomware_detection/raw/master/screenshots/scan-files-0.3.0.png</screenshot>
     <dependencies>


### PR DESCRIPTION
The `appinfo/info.xml` did not contain a reference to the "website" (this repository) of the app other than the issue page. It would improve the user experience with the [app description page](https://apps.nextcloud.com/apps/ransomware_detection) and the description in NextCloud would link to the website. Also the link to the repository may be useful.

This PR adds reasonable entries for the `<website>` and `<repository>` tags to the info.xml.

Example [info.xml](https://github.com/nextcloud/ransomware_protection/blob/master/appinfo/info.xml) of the [nextcloud/ransomware_protection](https://github.com/nextcloud/ransomware_protection) app, which I used as template:
```
<website>https://github.com/nextcloud/ransomware_protection</website>
<bugs>https://github.com/nextcloud/ransomware_protection/issues</bugs>
<repository>https://github.com/nextcloud/ransomware_protection.git</repository>
```